### PR TITLE
Edited exceptions logic.

### DIFF
--- a/src/VK/Exceptions/Api/ExceptionMapper.php
+++ b/src/VK/Exceptions/Api/ExceptionMapper.php
@@ -8,237 +8,237 @@ class ExceptionMapper {
     public static function parse(VKApiError $error) {
         switch($error->getErrorCode()) {
             case 1:
-                return new VKApiUnknownException($error->getErrorMsg());
+                return new VKApiUnknownException($error);
             case 2:
-                return new VKApiDisabledException($error->getErrorMsg());
+                return new VKApiDisabledException($error);
             case 3:
-                return new VKApiMethodException($error->getErrorMsg());
+                return new VKApiMethodException($error);
             case 4:
-                return new VKApiSignatureException($error->getErrorMsg());
+                return new VKApiSignatureException($error);
             case 5:
-                return new VKApiAuthException($error->getErrorMsg());
+                return new VKApiAuthException($error);
             case 6:
-                return new VKApiTooManyException($error->getErrorMsg());
+                return new VKApiTooManyException($error);
             case 7:
-                return new VKApiPermissionException($error->getErrorMsg());
+                return new VKApiPermissionException($error);
             case 8:
-                return new VKApiRequestException($error->getErrorMsg());
+                return new VKApiRequestException($error);
             case 9:
-                return new VKApiFloodException($error->getErrorMsg());
+                return new VKApiFloodException($error);
             case 10:
-                return new VKApiServerException($error->getErrorMsg());
+                return new VKApiServerException($error);
             case 11:
-                return new VKApiEnabledInTestException($error->getErrorMsg());
+                return new VKApiEnabledInTestException($error);
             case 14:
-                return new VKApiCaptchaException($error->getErrorMsg());
+                return new VKApiCaptchaException($error);
             case 15:
-                return new VKApiAccessException($error->getErrorMsg());
+                return new VKApiAccessException($error);
             case 16:
-                return new VKApiAuthHttpsException($error->getErrorMsg());
+                return new VKApiAuthHttpsException($error);
             case 17:
-                return new VKApiAuthValidationException($error->getErrorMsg());
+                return new VKApiAuthValidationException($error);
             case 18:
-                return new VKApiUserDeletedException($error->getErrorMsg());
+                return new VKApiUserDeletedException($error);
             case 19:
-                return new VKApiBlockedException($error->getErrorMsg());
+                return new VKApiBlockedException($error);
             case 20:
-                return new VKApiMethodPermissionException($error->getErrorMsg());
+                return new VKApiMethodPermissionException($error);
             case 21:
-                return new VKApiMethodAdsException($error->getErrorMsg());
+                return new VKApiMethodAdsException($error);
             case 22:
-                return new VKApiUploadException($error->getErrorMsg());
+                return new VKApiUploadException($error);
             case 23:
-                return new VKApiMethodDisabledException($error->getErrorMsg());
+                return new VKApiMethodDisabledException($error);
             case 24:
-                return new VKApiNeedConfirmationException($error->getErrorMsg());
+                return new VKApiNeedConfirmationException($error);
             case 100:
-                return new VKApiParamException($error->getErrorMsg());
+                return new VKApiParamException($error);
             case 101:
-                return new VKApiParamApiIdException($error->getErrorMsg());
+                return new VKApiParamApiIdException($error);
             case 103:
-                return new VKApiLimitsException($error->getErrorMsg());
+                return new VKApiLimitsException($error);
             case 104:
-                return new VKApiNotFoundException($error->getErrorMsg());
+                return new VKApiNotFoundException($error);
             case 105:
-                return new VKApiSaveFileException($error->getErrorMsg());
+                return new VKApiSaveFileException($error);
             case 106:
-                return new VKApiActionFailedException($error->getErrorMsg());
+                return new VKApiActionFailedException($error);
             case 113:
-                return new VKApiParamUserIdException($error->getErrorMsg());
+                return new VKApiParamUserIdException($error);
             case 114:
-                return new VKApiParamAlbumIdException($error->getErrorMsg());
+                return new VKApiParamAlbumIdException($error);
             case 118:
-                return new VKApiParamServerException($error->getErrorMsg());
+                return new VKApiParamServerException($error);
             case 119:
-                return new VKApiParamTitleException($error->getErrorMsg());
+                return new VKApiParamTitleException($error);
             case 121:
-                return new VKApiParamHashException($error->getErrorMsg());
+                return new VKApiParamHashException($error);
             case 122:
-                return new VKApiParamPhotosException($error->getErrorMsg());
+                return new VKApiParamPhotosException($error);
             case 125:
-                return new VKApiParamGroupIdException($error->getErrorMsg());
+                return new VKApiParamGroupIdException($error);
             case 129:
-                return new VKApiParamPhotoException($error->getErrorMsg());
+                return new VKApiParamPhotoException($error);
             case 140:
-                return new VKApiParamPageIdException($error->getErrorMsg());
+                return new VKApiParamPageIdException($error);
             case 141:
-                return new VKApiAccessPageException($error->getErrorMsg());
+                return new VKApiAccessPageException($error);
             case 146:
-                return new VKApiMobileNotActivatedException($error->getErrorMsg());
+                return new VKApiMobileNotActivatedException($error);
             case 147:
-                return new VKApiInsufficientFundsException($error->getErrorMsg());
+                return new VKApiInsufficientFundsException($error);
             case 148:
-                return new VKApiAccessMenuException($error->getErrorMsg());
+                return new VKApiAccessMenuException($error);
             case 150:
-                return new VKApiParamTimestampException($error->getErrorMsg());
+                return new VKApiParamTimestampException($error);
             case 171:
-                return new VKApiFriendsListIdException($error->getErrorMsg());
+                return new VKApiFriendsListIdException($error);
             case 173:
-                return new VKApiFriendsListLimitException($error->getErrorMsg());
+                return new VKApiFriendsListLimitException($error);
             case 174:
-                return new VKApiFriendsAddYourselfException($error->getErrorMsg());
+                return new VKApiFriendsAddYourselfException($error);
             case 175:
-                return new VKApiFriendsAddInEnemyException($error->getErrorMsg());
+                return new VKApiFriendsAddInEnemyException($error);
             case 176:
-                return new VKApiFriendsAddEnemyException($error->getErrorMsg());
+                return new VKApiFriendsAddEnemyException($error);
             case 180:
-                return new VKApiParamNoteIdException($error->getErrorMsg());
+                return new VKApiParamNoteIdException($error);
             case 181:
-                return new VKApiAccessNoteException($error->getErrorMsg());
+                return new VKApiAccessNoteException($error);
             case 182:
-                return new VKApiAccessNoteCommentException($error->getErrorMsg());
+                return new VKApiAccessNoteCommentException($error);
             case 183:
-                return new VKApiAccessCommentException($error->getErrorMsg());
+                return new VKApiAccessCommentException($error);
             case 190:
-                return new VKApiSameCheckinException($error->getErrorMsg());
+                return new VKApiSameCheckinException($error);
             case 191:
-                return new VKApiAccessCheckinException($error->getErrorMsg());
+                return new VKApiAccessCheckinException($error);
             case 200:
-                return new VKApiAccessAlbumException($error->getErrorMsg());
+                return new VKApiAccessAlbumException($error);
             case 201:
-                return new VKApiAccessAudioException($error->getErrorMsg());
+                return new VKApiAccessAudioException($error);
             case 203:
-                return new VKApiAccessGroupException($error->getErrorMsg());
+                return new VKApiAccessGroupException($error);
             case 204:
-                return new VKApiAccessVideoException($error->getErrorMsg());
+                return new VKApiAccessVideoException($error);
             case 205:
-                return new VKApiAccessMarketException($error->getErrorMsg());
+                return new VKApiAccessMarketException($error);
             case 210:
-                return new VKApiWallAccessPostException($error->getErrorMsg());
+                return new VKApiWallAccessPostException($error);
             case 211:
-                return new VKApiWallAccessCommentException($error->getErrorMsg());
+                return new VKApiWallAccessCommentException($error);
             case 212:
-                return new VKApiWallAccessRepliesException($error->getErrorMsg());
+                return new VKApiWallAccessRepliesException($error);
             case 213:
-                return new VKApiWallAccessAddReplyException($error->getErrorMsg());
+                return new VKApiWallAccessAddReplyException($error);
             case 214:
-                return new VKApiWallAddPostException($error->getErrorMsg());
+                return new VKApiWallAddPostException($error);
             case 219:
-                return new VKApiWallAdsPublishedException($error->getErrorMsg());
+                return new VKApiWallAdsPublishedException($error);
             case 220:
-                return new VKApiWallTooManyRecipientsException($error->getErrorMsg());
+                return new VKApiWallTooManyRecipientsException($error);
             case 221:
-                return new VKApiStatusNoAudioException($error->getErrorMsg());
+                return new VKApiStatusNoAudioException($error);
             case 222:
-                return new VKApiWallLinksForbiddenException($error->getErrorMsg());
+                return new VKApiWallLinksForbiddenException($error);
             case 224:
-                return new VKApiWallAdsPostLimitReachedException($error->getErrorMsg());
+                return new VKApiWallAdsPostLimitReachedException($error);
             case 250:
-                return new VKApiPollsAccessException($error->getErrorMsg());
+                return new VKApiPollsAccessException($error);
             case 251:
-                return new VKApiPollsPollIdException($error->getErrorMsg());
+                return new VKApiPollsPollIdException($error);
             case 252:
-                return new VKApiPollsAnswerIdException($error->getErrorMsg());
+                return new VKApiPollsAnswerIdException($error);
             case 260:
-                return new VKApiAccessGroupsException($error->getErrorMsg());
+                return new VKApiAccessGroupsException($error);
             case 300:
-                return new VKApiAlbumFullException($error->getErrorMsg());
+                return new VKApiAlbumFullException($error);
             case 302:
-                return new VKApiAlbumsLimitException($error->getErrorMsg());
+                return new VKApiAlbumsLimitException($error);
             case 500:
-                return new VKApiVotesPermissionException($error->getErrorMsg());
+                return new VKApiVotesPermissionException($error);
             case 503:
-                return new VKApiVotesException($error->getErrorMsg());
+                return new VKApiVotesException($error);
             case 600:
-                return new VKApiAdsPermissionException($error->getErrorMsg());
+                return new VKApiAdsPermissionException($error);
             case 601:
-                return new VKApiWeightedFloodException($error->getErrorMsg());
+                return new VKApiWeightedFloodException($error);
             case 602:
-                return new VKApiAdsPartialSuccessException($error->getErrorMsg());
+                return new VKApiAdsPartialSuccessException($error);
             case 603:
-                return new VKApiAdsSpecificException($error->getErrorMsg());
+                return new VKApiAdsSpecificException($error);
             case 700:
-                return new VKApiGroupChangeCreatorException($error->getErrorMsg());
+                return new VKApiGroupChangeCreatorException($error);
             case 701:
-                return new VKApiGroupNotInClubException($error->getErrorMsg());
+                return new VKApiGroupNotInClubException($error);
             case 702:
-                return new VKApiGroupTooManyOfficersException($error->getErrorMsg());
+                return new VKApiGroupTooManyOfficersException($error);
             case 800:
-                return new VKApiVideoAlreadyAddedException($error->getErrorMsg());
+                return new VKApiVideoAlreadyAddedException($error);
             case 801:
-                return new VKApiVideoCommentsClosedException($error->getErrorMsg());
+                return new VKApiVideoCommentsClosedException($error);
             case 900:
-                return new VKApiMessagesUserBlockedException($error->getErrorMsg());
+                return new VKApiMessagesUserBlockedException($error);
             case 901:
-                return new VKApiMessagesDenySendException($error->getErrorMsg());
+                return new VKApiMessagesDenySendException($error);
             case 902:
-                return new VKApiMessagesPrivacyException($error->getErrorMsg());
+                return new VKApiMessagesPrivacyException($error);
             case 913:
-                return new VKApiMessagesForwardAmountExceededException($error->getErrorMsg());
+                return new VKApiMessagesForwardAmountExceededException($error);
             case 921:
-                return new VKApiMessagesForwardException($error->getErrorMsg());
+                return new VKApiMessagesForwardException($error);
             case 1000:
-                return new VKApiParamPhoneException($error->getErrorMsg());
+                return new VKApiParamPhoneException($error);
             case 1004:
-                return new VKApiPhoneAlreadyUsedException($error->getErrorMsg());
+                return new VKApiPhoneAlreadyUsedException($error);
             case 1105:
-                return new VKApiAuthFloodException($error->getErrorMsg());
+                return new VKApiAuthFloodException($error);
             case 1110:
-                return new VKApiAuthParamCodeException($error->getErrorMsg());
+                return new VKApiAuthParamCodeException($error);
             case 1111:
-                return new VKApiAuthParamPasswordException($error->getErrorMsg());
+                return new VKApiAuthParamPasswordException($error);
             case 1112:
-                return new VKApiAuthDelayException($error->getErrorMsg());
+                return new VKApiAuthDelayException($error);
             case 1150:
-                return new VKApiParamDocIdException($error->getErrorMsg());
+                return new VKApiParamDocIdException($error);
             case 1151:
-                return new VKApiParamDocDeleteAccessException($error->getErrorMsg());
+                return new VKApiParamDocDeleteAccessException($error);
             case 1152:
-                return new VKApiParamDocTitleException($error->getErrorMsg());
+                return new VKApiParamDocTitleException($error);
             case 1153:
-                return new VKApiParamDocAccessException($error->getErrorMsg());
+                return new VKApiParamDocAccessException($error);
             case 1160:
-                return new VKApiPhotoChangedException($error->getErrorMsg());
+                return new VKApiPhotoChangedException($error);
             case 1170:
-                return new VKApiTooManyListsException($error->getErrorMsg());
+                return new VKApiTooManyListsException($error);
             case 1251:
-                return new VKApiAppsAlreadyUnlockedException($error->getErrorMsg());
+                return new VKApiAppsAlreadyUnlockedException($error);
             case 1260:
-                return new VKApiInvalidAddressException($error->getErrorMsg());
+                return new VKApiInvalidAddressException($error);
             case 1310:
-                return new VKApiCommunitiesCatalogDisabledException($error->getErrorMsg());
+                return new VKApiCommunitiesCatalogDisabledException($error);
             case 1311:
-                return new VKApiCommunitiesCategoriesDisabledException($error->getErrorMsg());
+                return new VKApiCommunitiesCategoriesDisabledException($error);
             case 1400:
-                return new VKApiMarketRestoreTooLateException($error->getErrorMsg());
+                return new VKApiMarketRestoreTooLateException($error);
             case 1401:
-                return new VKApiMarketCommentsClosedException($error->getErrorMsg());
+                return new VKApiMarketCommentsClosedException($error);
             case 1402:
-                return new VKApiMarketAlbumNotFoundException($error->getErrorMsg());
+                return new VKApiMarketAlbumNotFoundException($error);
             case 1403:
-                return new VKApiMarketItemNotFoundException($error->getErrorMsg());
+                return new VKApiMarketItemNotFoundException($error);
             case 1404:
-                return new VKApiMarketItemAlreadyAddedException($error->getErrorMsg());
+                return new VKApiMarketItemAlreadyAddedException($error);
             case 1405:
-                return new VKApiMarketTooManyItemsException($error->getErrorMsg());
+                return new VKApiMarketTooManyItemsException($error);
             case 1406:
-                return new VKApiMarketTooManyItemsInAlbumException($error->getErrorMsg());
+                return new VKApiMarketTooManyItemsInAlbumException($error);
             case 1407:
-                return new VKApiMarketTooManyAlbumsException($error->getErrorMsg());
+                return new VKApiMarketTooManyAlbumsException($error);
             case 1600:
-                return new VKApiStoryExpiredException($error->getErrorMsg());
+                return new VKApiStoryExpiredException($error);
             case 1602:
-                return new VKApiIncorrectReplyPrivacyException($error->getErrorMsg());
+                return new VKApiIncorrectReplyPrivacyException($error);
             default:
                 return new VKApiException($error->getErrorCode(), $error->getErrorMsg(), 'Unknown error');
         }

--- a/src/VK/Exceptions/Api/VKApiAccessAlbumException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessAlbumException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessAlbumException extends VKApiException {
     /**
      * VKApiAccessAlbumException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(200, 'Access denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(200, 'Access denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessAudioException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessAudioException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessAudioException extends VKApiException {
     /**
      * VKApiAccessAudioException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(201, 'Access denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(201, 'Access denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessCheckinException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessCheckinException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessCheckinException extends VKApiException {
     /**
      * VKApiAccessCheckinException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(191, 'Access to checkins denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(191, 'Access to checkins denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessCommentException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessCommentException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessCommentException extends VKApiException {
     /**
      * VKApiAccessCommentException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(183, 'Access to comment denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(183, 'Access to comment denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessException extends VKApiException {
     /**
      * VKApiAccessException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(15, 'Access denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(15, 'Access denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessGroupException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessGroupException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessGroupException extends VKApiException {
     /**
      * VKApiAccessGroupException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(203, 'Access to group denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(203, 'Access to group denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessGroupsException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessGroupsException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessGroupsException extends VKApiException {
     /**
      * VKApiAccessGroupsException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(260, 'Access to the groups list is denied due to the user\'s privacy settings', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(260, 'Access to the groups list is denied due to the user\'s privacy settings', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessMarketException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessMarketException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessMarketException extends VKApiException {
     /**
      * VKApiAccessMarketException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(205, 'Access denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(205, 'Access denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessMenuException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessMenuException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessMenuException extends VKApiException {
     /**
      * VKApiAccessMenuException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(148, 'Access to the menu of the user denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(148, 'Access to the menu of the user denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessNoteCommentException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessNoteCommentException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessNoteCommentException extends VKApiException {
     /**
      * VKApiAccessNoteCommentException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(182, 'You can\'t comment this note', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(182, 'You can\'t comment this note', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessNoteException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessNoteException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessNoteException extends VKApiException {
     /**
      * VKApiAccessNoteException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(181, 'Access to note denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(181, 'Access to note denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessPageException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessPageException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessPageException extends VKApiException {
     /**
      * VKApiAccessPageException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(141, 'Access to page denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(141, 'Access to page denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAccessVideoException.php
+++ b/src/VK/Exceptions/Api/VKApiAccessVideoException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAccessVideoException extends VKApiException {
     /**
      * VKApiAccessVideoException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(204, 'Access denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(204, 'Access denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiActionFailedException.php
+++ b/src/VK/Exceptions/Api/VKApiActionFailedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiActionFailedException extends VKApiException {
     /**
      * VKApiActionFailedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(106, 'Unable to process action', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(106, 'Unable to process action', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAdsPartialSuccessException.php
+++ b/src/VK/Exceptions/Api/VKApiAdsPartialSuccessException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAdsPartialSuccessException extends VKApiException {
     /**
      * VKApiAdsPartialSuccessException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(602, 'Some part of the request has not been completed', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(602, 'Some part of the request has not been completed', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAdsPermissionException.php
+++ b/src/VK/Exceptions/Api/VKApiAdsPermissionException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAdsPermissionException extends VKApiException {
     /**
      * VKApiAdsPermissionException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(600, 'Permission denied. You have no access to operations specified with given object(s)', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(600, 'Permission denied. You have no access to operations specified with given object(s)', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAdsSpecificException.php
+++ b/src/VK/Exceptions/Api/VKApiAdsSpecificException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAdsSpecificException extends VKApiException {
     /**
      * VKApiAdsSpecificException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(603, 'Some ads error occured', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(603, 'Some ads error occured', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAlbumFullException.php
+++ b/src/VK/Exceptions/Api/VKApiAlbumFullException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAlbumFullException extends VKApiException {
     /**
      * VKApiAlbumFullException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(300, 'This album is full', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(300, 'This album is full', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAlbumsLimitException.php
+++ b/src/VK/Exceptions/Api/VKApiAlbumsLimitException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAlbumsLimitException extends VKApiException {
     /**
      * VKApiAlbumsLimitException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(302, 'Albums number limit is reached', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(302, 'Albums number limit is reached', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAppsAlreadyUnlockedException.php
+++ b/src/VK/Exceptions/Api/VKApiAppsAlreadyUnlockedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAppsAlreadyUnlockedException extends VKApiException {
     /**
      * VKApiAppsAlreadyUnlockedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1251, 'This achievement is already unlocked', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1251, 'This achievement is already unlocked', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAuthDelayException.php
+++ b/src/VK/Exceptions/Api/VKApiAuthDelayException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAuthDelayException extends VKApiException {
     /**
      * VKApiAuthDelayException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1112, 'Processing. Try later', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1112, 'Processing. Try later', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAuthException.php
+++ b/src/VK/Exceptions/Api/VKApiAuthException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAuthException extends VKApiException {
     /**
      * VKApiAuthException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(5, 'User authorization failed', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(5, 'User authorization failed', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAuthFloodException.php
+++ b/src/VK/Exceptions/Api/VKApiAuthFloodException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAuthFloodException extends VKApiException {
     /**
      * VKApiAuthFloodException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1105, 'Too many auth attempts, try again later', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1105, 'Too many auth attempts, try again later', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAuthHttpsException.php
+++ b/src/VK/Exceptions/Api/VKApiAuthHttpsException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAuthHttpsException extends VKApiException {
     /**
      * VKApiAuthHttpsException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(16, 'HTTP authorization failed', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(16, 'HTTP authorization failed', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAuthParamCodeException.php
+++ b/src/VK/Exceptions/Api/VKApiAuthParamCodeException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAuthParamCodeException extends VKApiException {
     /**
      * VKApiAuthParamCodeException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1110, 'Incorrect code', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1110, 'Incorrect code', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAuthParamPasswordException.php
+++ b/src/VK/Exceptions/Api/VKApiAuthParamPasswordException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAuthParamPasswordException extends VKApiException {
     /**
      * VKApiAuthParamPasswordException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1111, 'Invalid password', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1111, 'Invalid password', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiAuthValidationException.php
+++ b/src/VK/Exceptions/Api/VKApiAuthValidationException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiAuthValidationException extends VKApiException {
     /**
      * VKApiAuthValidationException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(17, 'Validation required', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(17, 'Validation required', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiBlockedException.php
+++ b/src/VK/Exceptions/Api/VKApiBlockedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiBlockedException extends VKApiException {
     /**
      * VKApiBlockedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(19, 'Content blocked', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(19, 'Content blocked', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiCaptchaException.php
+++ b/src/VK/Exceptions/Api/VKApiCaptchaException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiCaptchaException extends VKApiException {
     /**
      * VKApiCaptchaException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(14, 'Captcha needed', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(14, 'Captcha needed', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiCommunitiesCatalogDisabledException.php
+++ b/src/VK/Exceptions/Api/VKApiCommunitiesCatalogDisabledException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiCommunitiesCatalogDisabledException extends VKApiException {
     /**
      * VKApiCommunitiesCatalogDisabledException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1310, 'Catalog is not available for this user', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1310, 'Catalog is not available for this user', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiCommunitiesCategoriesDisabledException.php
+++ b/src/VK/Exceptions/Api/VKApiCommunitiesCategoriesDisabledException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiCommunitiesCategoriesDisabledException extends VKApiException {
     /**
      * VKApiCommunitiesCategoriesDisabledException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1311, 'Catalog categories are not available for this user', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1311, 'Catalog categories are not available for this user', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiDisabledException.php
+++ b/src/VK/Exceptions/Api/VKApiDisabledException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiDisabledException extends VKApiException {
     /**
      * VKApiDisabledException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(2, 'Application is disabled. Enable your application or use test mode', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(2, 'Application is disabled. Enable your application or use test mode', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiEnabledInTestException.php
+++ b/src/VK/Exceptions/Api/VKApiEnabledInTestException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiEnabledInTestException extends VKApiException {
     /**
      * VKApiEnabledInTestException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(11, 'In test mode application should be disabled or user should be authorized', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(11, 'In test mode application should be disabled or user should be authorized', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiFloodException.php
+++ b/src/VK/Exceptions/Api/VKApiFloodException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiFloodException extends VKApiException {
     /**
      * VKApiFloodException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(9, 'Flood control', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(9, 'Flood control', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiFriendsAddEnemyException.php
+++ b/src/VK/Exceptions/Api/VKApiFriendsAddEnemyException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiFriendsAddEnemyException extends VKApiException {
     /**
      * VKApiFriendsAddEnemyException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(176, 'Cannot add this user to friends as you put him on blacklist', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(176, 'Cannot add this user to friends as you put him on blacklist', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiFriendsAddInEnemyException.php
+++ b/src/VK/Exceptions/Api/VKApiFriendsAddInEnemyException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiFriendsAddInEnemyException extends VKApiException {
     /**
      * VKApiFriendsAddInEnemyException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(175, 'Cannot add this user to friends as they have put you on their blacklist', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(175, 'Cannot add this user to friends as they have put you on their blacklist', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiFriendsAddYourselfException.php
+++ b/src/VK/Exceptions/Api/VKApiFriendsAddYourselfException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiFriendsAddYourselfException extends VKApiException {
     /**
      * VKApiFriendsAddYourselfException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(174, 'Cannot add user himself as friend', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(174, 'Cannot add user himself as friend', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiFriendsListIdException.php
+++ b/src/VK/Exceptions/Api/VKApiFriendsListIdException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiFriendsListIdException extends VKApiException {
     /**
      * VKApiFriendsListIdException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(171, 'Invalid list id', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(171, 'Invalid list id', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiFriendsListLimitException.php
+++ b/src/VK/Exceptions/Api/VKApiFriendsListLimitException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiFriendsListLimitException extends VKApiException {
     /**
      * VKApiFriendsListLimitException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(173, 'Reached the maximum number of lists', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(173, 'Reached the maximum number of lists', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiGroupChangeCreatorException.php
+++ b/src/VK/Exceptions/Api/VKApiGroupChangeCreatorException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiGroupChangeCreatorException extends VKApiException {
     /**
      * VKApiGroupChangeCreatorException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(700, 'Cannot edit creator role', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(700, 'Cannot edit creator role', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiGroupNotInClubException.php
+++ b/src/VK/Exceptions/Api/VKApiGroupNotInClubException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiGroupNotInClubException extends VKApiException {
     /**
      * VKApiGroupNotInClubException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(701, 'User should be in club', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(701, 'User should be in club', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiGroupTooManyOfficersException.php
+++ b/src/VK/Exceptions/Api/VKApiGroupTooManyOfficersException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiGroupTooManyOfficersException extends VKApiException {
     /**
      * VKApiGroupTooManyOfficersException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(702, 'Too many officers in club', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(702, 'Too many officers in club', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiIncorrectReplyPrivacyException.php
+++ b/src/VK/Exceptions/Api/VKApiIncorrectReplyPrivacyException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiIncorrectReplyPrivacyException extends VKApiException {
     /**
      * VKApiIncorrectReplyPrivacyException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1602, 'Incorrect reply privacy', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1602, 'Incorrect reply privacy', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiInsufficientFundsException.php
+++ b/src/VK/Exceptions/Api/VKApiInsufficientFundsException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiInsufficientFundsException extends VKApiException {
     /**
      * VKApiInsufficientFundsException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(147, 'Application has insufficient funds', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(147, 'Application has insufficient funds', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiInvalidAddressException.php
+++ b/src/VK/Exceptions/Api/VKApiInvalidAddressException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiInvalidAddressException extends VKApiException {
     /**
      * VKApiInvalidAddressException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1260, 'Invalid screen name', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1260, 'Invalid screen name', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiLimitsException.php
+++ b/src/VK/Exceptions/Api/VKApiLimitsException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiLimitsException extends VKApiException {
     /**
      * VKApiLimitsException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(103, 'Out of limits', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(103, 'Out of limits', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMarketAlbumNotFoundException.php
+++ b/src/VK/Exceptions/Api/VKApiMarketAlbumNotFoundException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMarketAlbumNotFoundException extends VKApiException {
     /**
      * VKApiMarketAlbumNotFoundException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1402, 'Album not found', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1402, 'Album not found', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMarketCommentsClosedException.php
+++ b/src/VK/Exceptions/Api/VKApiMarketCommentsClosedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMarketCommentsClosedException extends VKApiException {
     /**
      * VKApiMarketCommentsClosedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1401, 'Comments for this market are closed', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1401, 'Comments for this market are closed', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMarketItemAlreadyAddedException.php
+++ b/src/VK/Exceptions/Api/VKApiMarketItemAlreadyAddedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMarketItemAlreadyAddedException extends VKApiException {
     /**
      * VKApiMarketItemAlreadyAddedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1404, 'Item already added to album', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1404, 'Item already added to album', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMarketItemNotFoundException.php
+++ b/src/VK/Exceptions/Api/VKApiMarketItemNotFoundException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMarketItemNotFoundException extends VKApiException {
     /**
      * VKApiMarketItemNotFoundException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1403, 'Item not found', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1403, 'Item not found', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMarketRestoreTooLateException.php
+++ b/src/VK/Exceptions/Api/VKApiMarketRestoreTooLateException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMarketRestoreTooLateException extends VKApiException {
     /**
      * VKApiMarketRestoreTooLateException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1400, 'Too late for restore', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1400, 'Too late for restore', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMarketTooManyAlbumsException.php
+++ b/src/VK/Exceptions/Api/VKApiMarketTooManyAlbumsException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMarketTooManyAlbumsException extends VKApiException {
     /**
      * VKApiMarketTooManyAlbumsException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1407, 'Too many albums', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1407, 'Too many albums', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMarketTooManyItemsException.php
+++ b/src/VK/Exceptions/Api/VKApiMarketTooManyItemsException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMarketTooManyItemsException extends VKApiException {
     /**
      * VKApiMarketTooManyItemsException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1405, 'Too many items', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1405, 'Too many items', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMarketTooManyItemsInAlbumException.php
+++ b/src/VK/Exceptions/Api/VKApiMarketTooManyItemsInAlbumException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMarketTooManyItemsInAlbumException extends VKApiException {
     /**
      * VKApiMarketTooManyItemsInAlbumException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1406, 'Too many items in album', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1406, 'Too many items in album', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMessagesDenySendException.php
+++ b/src/VK/Exceptions/Api/VKApiMessagesDenySendException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMessagesDenySendException extends VKApiException {
     /**
      * VKApiMessagesDenySendException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(901, 'Can\'t send messages for users without dialogs', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(901, 'Can\'t send messages for users without dialogs', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMessagesForwardAmountExceededException.php
+++ b/src/VK/Exceptions/Api/VKApiMessagesForwardAmountExceededException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMessagesForwardAmountExceededException extends VKApiException {
     /**
      * VKApiMessagesForwardAmountExceededException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(913, 'Too many forwarded messages', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(913, 'Too many forwarded messages', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMessagesForwardException.php
+++ b/src/VK/Exceptions/Api/VKApiMessagesForwardException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMessagesForwardException extends VKApiException {
     /**
      * VKApiMessagesForwardException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(921, 'Can\'t forward these messages', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(921, 'Can\'t forward these messages', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMessagesPrivacyException.php
+++ b/src/VK/Exceptions/Api/VKApiMessagesPrivacyException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMessagesPrivacyException extends VKApiException {
     /**
      * VKApiMessagesPrivacyException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(902, 'Can\'t send messages to this user due to their privacy settings', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(902, 'Can\'t send messages to this user due to their privacy settings', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMessagesUserBlockedException.php
+++ b/src/VK/Exceptions/Api/VKApiMessagesUserBlockedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMessagesUserBlockedException extends VKApiException {
     /**
      * VKApiMessagesUserBlockedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(900, 'Can\'t send messages for users from blacklist', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(900, 'Can\'t send messages for users from blacklist', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMethodAdsException.php
+++ b/src/VK/Exceptions/Api/VKApiMethodAdsException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMethodAdsException extends VKApiException {
     /**
      * VKApiMethodAdsException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(21, 'Permission to perform this action is allowed only for standalone and OpenAPI applications', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(21, 'Permission to perform this action is allowed only for standalone and OpenAPI applications', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMethodDisabledException.php
+++ b/src/VK/Exceptions/Api/VKApiMethodDisabledException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMethodDisabledException extends VKApiException {
     /**
      * VKApiMethodDisabledException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(23, 'This method was disabled', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(23, 'This method was disabled', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMethodException.php
+++ b/src/VK/Exceptions/Api/VKApiMethodException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMethodException extends VKApiException {
     /**
      * VKApiMethodException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(3, 'Unknown method passed', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(3, 'Unknown method passed', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMethodPermissionException.php
+++ b/src/VK/Exceptions/Api/VKApiMethodPermissionException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMethodPermissionException extends VKApiException {
     /**
      * VKApiMethodPermissionException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(20, 'Permission to perform this action is denied for non-standalone applications', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(20, 'Permission to perform this action is denied for non-standalone applications', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiMobileNotActivatedException.php
+++ b/src/VK/Exceptions/Api/VKApiMobileNotActivatedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiMobileNotActivatedException extends VKApiException {
     /**
      * VKApiMobileNotActivatedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(146, 'The mobile number of the user is unknown', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(146, 'The mobile number of the user is unknown', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiNeedConfirmationException.php
+++ b/src/VK/Exceptions/Api/VKApiNeedConfirmationException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiNeedConfirmationException extends VKApiException {
     /**
      * VKApiNeedConfirmationException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(24, 'Confirmation required', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(24, 'Confirmation required', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiNotFoundException.php
+++ b/src/VK/Exceptions/Api/VKApiNotFoundException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiNotFoundException extends VKApiException {
     /**
      * VKApiNotFoundException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(104, 'Not found', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(104, 'Not found', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamAlbumIdException.php
+++ b/src/VK/Exceptions/Api/VKApiParamAlbumIdException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamAlbumIdException extends VKApiException {
     /**
      * VKApiParamAlbumIdException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(114, 'Invalid album id', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(114, 'Invalid album id', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamApiIdException.php
+++ b/src/VK/Exceptions/Api/VKApiParamApiIdException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamApiIdException extends VKApiException {
     /**
      * VKApiParamApiIdException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(101, 'Invalid application API ID', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(101, 'Invalid application API ID', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamDocAccessException.php
+++ b/src/VK/Exceptions/Api/VKApiParamDocAccessException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamDocAccessException extends VKApiException {
     /**
      * VKApiParamDocAccessException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1153, 'Access to document is denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1153, 'Access to document is denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamDocDeleteAccessException.php
+++ b/src/VK/Exceptions/Api/VKApiParamDocDeleteAccessException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamDocDeleteAccessException extends VKApiException {
     /**
      * VKApiParamDocDeleteAccessException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1151, 'Access to document deleting is denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1151, 'Access to document deleting is denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamDocIdException.php
+++ b/src/VK/Exceptions/Api/VKApiParamDocIdException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamDocIdException extends VKApiException {
     /**
      * VKApiParamDocIdException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1150, 'Invalid document id', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1150, 'Invalid document id', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamDocTitleException.php
+++ b/src/VK/Exceptions/Api/VKApiParamDocTitleException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamDocTitleException extends VKApiException {
     /**
      * VKApiParamDocTitleException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1152, 'Invalid document title', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1152, 'Invalid document title', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamException.php
+++ b/src/VK/Exceptions/Api/VKApiParamException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamException extends VKApiException {
     /**
      * VKApiParamException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(100, 'One of the parameters specified was missing or invalid', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(100, 'One of the parameters specified was missing or invalid', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamGroupIdException.php
+++ b/src/VK/Exceptions/Api/VKApiParamGroupIdException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamGroupIdException extends VKApiException {
     /**
      * VKApiParamGroupIdException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(125, 'Invalid group id', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(125, 'Invalid group id', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamHashException.php
+++ b/src/VK/Exceptions/Api/VKApiParamHashException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamHashException extends VKApiException {
     /**
      * VKApiParamHashException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(121, 'Invalid hash', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(121, 'Invalid hash', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamNoteIdException.php
+++ b/src/VK/Exceptions/Api/VKApiParamNoteIdException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamNoteIdException extends VKApiException {
     /**
      * VKApiParamNoteIdException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(180, 'Note not found', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(180, 'Note not found', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamPageIdException.php
+++ b/src/VK/Exceptions/Api/VKApiParamPageIdException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamPageIdException extends VKApiException {
     /**
      * VKApiParamPageIdException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(140, 'Page not found', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(140, 'Page not found', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamPhoneException.php
+++ b/src/VK/Exceptions/Api/VKApiParamPhoneException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamPhoneException extends VKApiException {
     /**
      * VKApiParamPhoneException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1000, 'Invalid phone number', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1000, 'Invalid phone number', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamPhotoException.php
+++ b/src/VK/Exceptions/Api/VKApiParamPhotoException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamPhotoException extends VKApiException {
     /**
      * VKApiParamPhotoException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(129, 'Invalid photo', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(129, 'Invalid photo', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamPhotosException.php
+++ b/src/VK/Exceptions/Api/VKApiParamPhotosException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamPhotosException extends VKApiException {
     /**
      * VKApiParamPhotosException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(122, 'Invalid photos', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(122, 'Invalid photos', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamServerException.php
+++ b/src/VK/Exceptions/Api/VKApiParamServerException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamServerException extends VKApiException {
     /**
      * VKApiParamServerException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(118, 'Invalid server', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(118, 'Invalid server', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamTimestampException.php
+++ b/src/VK/Exceptions/Api/VKApiParamTimestampException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamTimestampException extends VKApiException {
     /**
      * VKApiParamTimestampException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(150, 'Invalid timestamp', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(150, 'Invalid timestamp', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamTitleException.php
+++ b/src/VK/Exceptions/Api/VKApiParamTitleException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamTitleException extends VKApiException {
     /**
      * VKApiParamTitleException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(119, 'Invalid title', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(119, 'Invalid title', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiParamUserIdException.php
+++ b/src/VK/Exceptions/Api/VKApiParamUserIdException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiParamUserIdException extends VKApiException {
     /**
      * VKApiParamUserIdException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(113, 'Invalid user id', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(113, 'Invalid user id', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiPermissionException.php
+++ b/src/VK/Exceptions/Api/VKApiPermissionException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiPermissionException extends VKApiException {
     /**
      * VKApiPermissionException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(7, 'Permission to perform this action is denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(7, 'Permission to perform this action is denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiPhoneAlreadyUsedException.php
+++ b/src/VK/Exceptions/Api/VKApiPhoneAlreadyUsedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiPhoneAlreadyUsedException extends VKApiException {
     /**
      * VKApiPhoneAlreadyUsedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1004, 'This phone number is used by another user', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1004, 'This phone number is used by another user', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiPhotoChangedException.php
+++ b/src/VK/Exceptions/Api/VKApiPhotoChangedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiPhotoChangedException extends VKApiException {
     /**
      * VKApiPhotoChangedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1160, 'Original photo was changed', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1160, 'Original photo was changed', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiPollsAccessException.php
+++ b/src/VK/Exceptions/Api/VKApiPollsAccessException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiPollsAccessException extends VKApiException {
     /**
      * VKApiPollsAccessException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(250, 'Access to poll denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(250, 'Access to poll denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiPollsAnswerIdException.php
+++ b/src/VK/Exceptions/Api/VKApiPollsAnswerIdException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiPollsAnswerIdException extends VKApiException {
     /**
      * VKApiPollsAnswerIdException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(252, 'Invalid answer id', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(252, 'Invalid answer id', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiPollsPollIdException.php
+++ b/src/VK/Exceptions/Api/VKApiPollsPollIdException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiPollsPollIdException extends VKApiException {
     /**
      * VKApiPollsPollIdException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(251, 'Invalid poll id', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(251, 'Invalid poll id', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiRequestException.php
+++ b/src/VK/Exceptions/Api/VKApiRequestException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiRequestException extends VKApiException {
     /**
      * VKApiRequestException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(8, 'Invalid request', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(8, 'Invalid request', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiSameCheckinException.php
+++ b/src/VK/Exceptions/Api/VKApiSameCheckinException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiSameCheckinException extends VKApiException {
     /**
      * VKApiSameCheckinException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(190, 'You have sent same checkin in last 10 minutes', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(190, 'You have sent same checkin in last 10 minutes', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiSaveFileException.php
+++ b/src/VK/Exceptions/Api/VKApiSaveFileException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiSaveFileException extends VKApiException {
     /**
      * VKApiSaveFileException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(105, 'Couldn\'t save file', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(105, 'Couldn\'t save file', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiServerException.php
+++ b/src/VK/Exceptions/Api/VKApiServerException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiServerException extends VKApiException {
     /**
      * VKApiServerException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(10, 'Internal server error', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(10, 'Internal server error', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiSignatureException.php
+++ b/src/VK/Exceptions/Api/VKApiSignatureException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiSignatureException extends VKApiException {
     /**
      * VKApiSignatureException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(4, 'Incorrect signature', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(4, 'Incorrect signature', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiStatusNoAudioException.php
+++ b/src/VK/Exceptions/Api/VKApiStatusNoAudioException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiStatusNoAudioException extends VKApiException {
     /**
      * VKApiStatusNoAudioException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(221, 'User disabled track name broadcast', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(221, 'User disabled track name broadcast', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiStoryExpiredException.php
+++ b/src/VK/Exceptions/Api/VKApiStoryExpiredException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiStoryExpiredException extends VKApiException {
     /**
      * VKApiStoryExpiredException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1600, 'Story has already expired', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1600, 'Story has already expired', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiTooManyException.php
+++ b/src/VK/Exceptions/Api/VKApiTooManyException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiTooManyException extends VKApiException {
     /**
      * VKApiTooManyException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(6, 'Too many requests per second', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(6, 'Too many requests per second', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiTooManyListsException.php
+++ b/src/VK/Exceptions/Api/VKApiTooManyListsException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiTooManyListsException extends VKApiException {
     /**
      * VKApiTooManyListsException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1170, 'Too many feed lists', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1170, 'Too many feed lists', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiUnknownException.php
+++ b/src/VK/Exceptions/Api/VKApiUnknownException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiUnknownException extends VKApiException {
     /**
      * VKApiUnknownException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(1, 'Unknown error occurred', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(1, 'Unknown error occurred', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiUploadException.php
+++ b/src/VK/Exceptions/Api/VKApiUploadException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiUploadException extends VKApiException {
     /**
      * VKApiUploadException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(22, 'Upload error', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(22, 'Upload error', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiUserDeletedException.php
+++ b/src/VK/Exceptions/Api/VKApiUserDeletedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiUserDeletedException extends VKApiException {
     /**
      * VKApiUserDeletedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(18, 'User was deleted or banned', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(18, 'User was deleted or banned', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiVideoAlreadyAddedException.php
+++ b/src/VK/Exceptions/Api/VKApiVideoAlreadyAddedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiVideoAlreadyAddedException extends VKApiException {
     /**
      * VKApiVideoAlreadyAddedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(800, 'This video is already added', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(800, 'This video is already added', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiVideoCommentsClosedException.php
+++ b/src/VK/Exceptions/Api/VKApiVideoCommentsClosedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiVideoCommentsClosedException extends VKApiException {
     /**
      * VKApiVideoCommentsClosedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(801, 'Comments for this video are closed', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(801, 'Comments for this video are closed', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiVotesException.php
+++ b/src/VK/Exceptions/Api/VKApiVotesException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiVotesException extends VKApiException {
     /**
      * VKApiVotesException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(503, 'Not enough votes', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(503, 'Not enough votes', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiVotesPermissionException.php
+++ b/src/VK/Exceptions/Api/VKApiVotesPermissionException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiVotesPermissionException extends VKApiException {
     /**
      * VKApiVotesPermissionException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(500, 'Permission denied. You must enable votes processing in application settings', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(500, 'Permission denied. You must enable votes processing in application settings', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiWallAccessAddReplyException.php
+++ b/src/VK/Exceptions/Api/VKApiWallAccessAddReplyException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiWallAccessAddReplyException extends VKApiException {
     /**
      * VKApiWallAccessAddReplyException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(213, 'Access to status replies denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(213, 'Access to status replies denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiWallAccessCommentException.php
+++ b/src/VK/Exceptions/Api/VKApiWallAccessCommentException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiWallAccessCommentException extends VKApiException {
     /**
      * VKApiWallAccessCommentException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(211, 'Access to wall\'s comment denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(211, 'Access to wall\'s comment denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiWallAccessPostException.php
+++ b/src/VK/Exceptions/Api/VKApiWallAccessPostException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiWallAccessPostException extends VKApiException {
     /**
      * VKApiWallAccessPostException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(210, 'Access to wall\'s post denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(210, 'Access to wall\'s post denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiWallAccessRepliesException.php
+++ b/src/VK/Exceptions/Api/VKApiWallAccessRepliesException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiWallAccessRepliesException extends VKApiException {
     /**
      * VKApiWallAccessRepliesException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(212, 'Access to post comments denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(212, 'Access to post comments denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiWallAddPostException.php
+++ b/src/VK/Exceptions/Api/VKApiWallAddPostException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiWallAddPostException extends VKApiException {
     /**
      * VKApiWallAddPostException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(214, 'Access to adding post denied', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(214, 'Access to adding post denied', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiWallAdsPostLimitReachedException.php
+++ b/src/VK/Exceptions/Api/VKApiWallAdsPostLimitReachedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiWallAdsPostLimitReachedException extends VKApiException {
     /**
      * VKApiWallAdsPostLimitReachedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(224, 'Too many ads posts', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(224, 'Too many ads posts', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiWallAdsPublishedException.php
+++ b/src/VK/Exceptions/Api/VKApiWallAdsPublishedException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiWallAdsPublishedException extends VKApiException {
     /**
      * VKApiWallAdsPublishedException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(219, 'Advertisement post was recently added', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(219, 'Advertisement post was recently added', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiWallLinksForbiddenException.php
+++ b/src/VK/Exceptions/Api/VKApiWallLinksForbiddenException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiWallLinksForbiddenException extends VKApiException {
     /**
      * VKApiWallLinksForbiddenException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(222, 'Hyperlinks are forbidden', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(222, 'Hyperlinks are forbidden', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiWallTooManyRecipientsException.php
+++ b/src/VK/Exceptions/Api/VKApiWallTooManyRecipientsException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiWallTooManyRecipientsException extends VKApiException {
     /**
      * VKApiWallTooManyRecipientsException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(220, 'Too many recipients', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(220, 'Too many recipients', $error);
     }
 }

--- a/src/VK/Exceptions/Api/VKApiWeightedFloodException.php
+++ b/src/VK/Exceptions/Api/VKApiWeightedFloodException.php
@@ -2,12 +2,14 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiWeightedFloodException extends VKApiException {
     /**
      * VKApiWeightedFloodException constructor.
-     * @param string $message
+     * @param VKApiError $error
      */
-    public function __construct(string $message) {
-        parent::__construct(601, 'Permission denied. You have requested too many actions this day. Try later.', $message);
+    public function __construct(VKApiError $error) {
+        parent::__construct(601, 'Permission denied. You have requested too many actions this day. Try later.', $error);
     }
 }

--- a/src/VK/Exceptions/VKApiException.php
+++ b/src/VK/Exceptions/VKApiException.php
@@ -2,6 +2,8 @@
 
 namespace VK\Exceptions\Api;
 
+use VK\Client\VKApiError;
+
 class VKApiException extends \Exception
 {
     /**
@@ -19,16 +21,23 @@ class VKApiException extends \Exception
      */
     protected $error_message;
 
+    /*
+     * @var VKApiError
+     */
+    protected $error;
+
     /**
      * VKApiException constructor.
      * @param int $error_code
      * @param string $description
-     * @param string $error_message
+     * @param VKApiError $error
      */
-    public function __construct(int $error_code, string $description, string $error_message) {
+    public function __construct(int $error_code, string $description, VKApiError $error) {
         $this->error_code = $error_code;
         $this->description = $description;
-        $this->error_message = $error_message;
+        $this->error_message = $error->getErrorMsg();
+        $this->error = $error;
+        parent::__construct($error->getErrorMsg(), $error_code);
     }
 
     /**
@@ -50,6 +59,13 @@ class VKApiException extends \Exception
      */
     public function getErrorMessage(): string {
         return $this->error_message;
+    }
+
+    /*
+     * @return VKApiError
+     */
+    public function getError(): VKApiError {
+        return $this->error;
     }
 
 


### PR DESCRIPTION
After changes that had been done in this PR you will be able to call **getError()** method from any exception instance that extends **VKApiException** to get **VKApiError** object.

It makes sense if e.g. **VKApiCaptchaException** was thrown. We need to get **captcha_sid**, **captcha_img**, etc. Having ability to get **VKApiError** object from **VKApiException** instance we can easily do it.

Also I've decided that it would be a good idea to call parent's constructor from **VKApiException**'s constructor to pass exception's code and message there.

Waiting for your reply.