### PR TITLE
The isNotificationsAllowed method for VK Apps.

### DIFF
--- a/src/VK/Actions/Apps.php
+++ b/src/VK/Actions/Apps.php
@@ -182,4 +182,20 @@ class Apps {
     public function getScore(string $access_token, array $params = array()) {
         return $this->request->post('apps.getScore', $access_token, $params);
     }
+
+    /**
+     * Returns the only is_allowed field (true or false).
+     *
+     * @param $access_token string
+     * @param $params array
+     *      - integer user_id:
+     *
+     * @return mixed
+     * @throws VKClientException in case of network error
+     * @throws VKApiException in case of API error
+     *
+     */
+    public function isNotificationsAllowed(string $access_token, array $params = array()) {
+        return $this->request->post('apps.isNotificationsAllowed', $access_token, $params);
+    }
 }


### PR DESCRIPTION
Не хватает метода для получения статуса доступности отправки нотификаций пользователю.
Приходится использовать конструкцию вида
`$vk->getRequest()->post('apps.isNotificationsAllowed', '6eba2da26eba2dqdqa2da2916ed267c166eba6eba212c53cbc5fc2a30f83', [
        'user_id'=>$user_id
    ]);`
Не очень удобно