### PR TITLE
Fix error in getHttpStatus() - correct processing of the HTTP/2 status

### DIFF
--- a/src/VK/TransportClient/Curl/CurlHttpClient.php
+++ b/src/VK/TransportClient/Curl/CurlHttpClient.php
@@ -184,7 +184,7 @@ class CurlHttpClient implements TransportClient {
      * @return int
      */
     protected function getHttpStatus(string $raw_response_header): int {
-        preg_match('|HTTP/\d\.\d\s+(\d+)\s+.*|', $raw_response_header, $match);
+        preg_match('|HTTP/\d(?:\.\d)?\s+(\d+)\s+.*|', $raw_response_header, $match);
         return (int)$match[1];
     }
 }


### PR DESCRIPTION
Fix error
`PHP Notice:  Undefined offset: 1 in /home/public_html/vendor/vkcom/vk-php-sdk/src/VK/TransportClient/Curl/CurlHttpClient.php on line 188`

When the server returns the `HTTP/2 200` status, the script crashes because can't handle it.
Fixed regular expression.