### PR TITLE
fixed passing getEvents query params

### DIFF
--- a/src/VK/CallbackApi/VKCallbackApiLongPollExecutor.php
+++ b/src/VK/CallbackApi/VKCallbackApiLongPollExecutor.php
@@ -157,8 +157,10 @@ class VKCallbackApiLongPollExecutor {
             static::PARAM_ACT  => static::VALUE_ACT
         );
 
+        $query_string = http_build_query($params);
+
         try {
-            $response = $this->http_client->get($host, $params);
+            $response = $this->http_client->get($host . '?' . $query_string);
         } catch (GuzzleException $exception) {
             throw new VKClientException($exception);
         }


### PR DESCRIPTION
Второй параметр метода get ожидает не параметры запроса, а опции его выполнения (можно увидеть, если в него провалиться). В итоге метод для получения событий из лонгполла выполняется без передачи в него параметров запроса и не работает. Поправил передачу параметров в метод.