### PR TITLE
Fix invalid namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ class CallbackApiMyHandler extends VK\CallbackApi\VKCallbackApiHandler {
 ```
 
 To start listening to LongPoll events, create an instance of your CallbackApiMyHandler class, instance of
-VK\CallbackApi\LongPoll\VKCallbackApiLongPollExecutor class and call method listen():
+VK\CallbackApi\VKCallbackApiLongPollExecutor class and call method listen():
 
 ```php
 $vk = new \VK\Client\VKApiClient();
@@ -345,8 +345,7 @@ $data = json_decode(file_get_contents('php://input'));
 $handler->parse($data);
 ```
 
-To handle events you need to override methods from VK\CallbackApi\Server\VKCallbackApiServerHandler class as shown
+To handle events you need to override methods from VK\CallbackApi\VKCallbackApiServerHandler class as shown
 above.
 
 `confirmation` event handler has 2 arguments: group id, and secret key. You need to override this method.
-

--- a/src/VK/CallbackApi/VKCallbackApiLongPollExecutor.php
+++ b/src/VK/CallbackApi/VKCallbackApiLongPollExecutor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Generator\Skeleton\skeleton\base\src\VK\CallbackApi;
+namespace VK\CallbackApi;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;

--- a/src/VK/CallbackApi/VKCallbackApiServerHandler.php
+++ b/src/VK/CallbackApi/VKCallbackApiServerHandler.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Generator\Skeleton\skeleton\base\src\VK\CallbackApi;
-
-use VK\CallbackApi\VKCallbackApiHandler;
+namespace VK\CallbackApi;
 
 abstract class VKCallbackApiServerHandler extends VKCallbackApiHandler {
     protected const EVENT_KEY_TYPE = 'type';


### PR DESCRIPTION
- Исправлены неймспейсы для VKCallbackApiLongPollExecutor.php и VKCallbackApiServerHandler.php в соответствии с PSR-4
- Исправлен README.md